### PR TITLE
Update Mekanism.cfg

### DIFF
--- a/config/Mekanism.cfg
+++ b/config/Mekanism.cfg
@@ -3,7 +3,7 @@
 client {
     I:AmbientLightingLevel=15
     B:CTMRenderer=true
-    B:EnableAmbientLighting=true
+    B:EnableAmbientLighting=false
     B:EnableMachineSounds=true
     B:EnablePlayerSounds=true
     B:Holidays=true
@@ -12,7 +12,7 @@ client {
 
     # If true, will reduce lagging between player sounds. Setting to false will reduce GC load
     B:ReplaceSoundsWhenResuming=true
-    D:SoundVolume=1.0
+    D:SoundVolume=0.4
 }
 
 


### PR DESCRIPTION
EnableAmbientLighting can cause fps to drop when you have multiple machines at work because of lighting updates.

SoundVolume because mekanism machines get noisy.